### PR TITLE
fixed bug about multibyte characters in the URL

### DIFF
--- a/CloudyTabs/JPAppDelegate.m
+++ b/CloudyTabs/JPAppDelegate.m
@@ -214,7 +214,7 @@
             
             NSMenuItem *tabMenuItem = [[NSMenuItem alloc] initWithTitle:tabDictionary[@"Title"] action:@selector(tabMenuItemClicked:) keyEquivalent:@""];
             
-            tabMenuItem.representedObject = tabDictionary[@"URL"];
+            tabMenuItem.representedObject = [tabDictionary[@"URL"] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             
             __block NSImage *image = [[DSFavIconManager sharedInstance] iconForURL:[NSURL URLWithString:tabMenuItem.representedObject] downloadHandler:^(NSImage *icon) {
                 icon.size = NSMakeSize(19, 19);


### PR DESCRIPTION
do not work app when URL includes multibyte chars.

#### Before
![](http://i.gyazo.com/08b086db79baf9e7c964828fe97aa414.png)

#### After
![](http://i.gyazo.com/c023961bf9f5e88c064cdfe6e24a84a4.png)


### My Environment
* OSX 10.9.5