### PR TITLE
Don't enable device names on update

### DIFF
--- a/CloudyTabs/JPAppDelegate.m
+++ b/CloudyTabs/JPAppDelegate.m
@@ -269,6 +269,9 @@
     [openAllTabsMenu setSubmenu:devicesMenu];
     
     NSMenuItem *openAtLoginItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Launch %@ At Login", @""), [self appBundleName]] action:@selector(openAtLoginToggled:) keyEquivalent:@""];
+    if (self.startAtLogin) {
+        [openAtLoginItem setState:YES];
+    }
     [self.menu addItem:openAtLoginItem];
     
     NSMenuItem *quitMenuItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Quit %@", @""), [self appBundleName]] action:@selector(quit:) keyEquivalent:@"q"];

--- a/CloudyTabs/JPAppDelegate.m
+++ b/CloudyTabs/JPAppDelegate.m
@@ -212,6 +212,7 @@
         
         // Add device to main list of tabs
         NSMenuItem *deviceMenuItem = [[NSMenuItem alloc] initWithTitle:[self deviceNameForID:deviceID] action:nil keyEquivalent:@""];
+        [deviceMenuItem setEnabled:NO];
         [self.menu addItem:deviceMenuItem];
         
         // Add device to "Open All Tabs From" submenu


### PR DESCRIPTION
If the menu is open during an update call the device names are set to enabled until the menu is deselected.

This pull request maintains the not enabled state of the device names, just as they are on launch.
