### PR TITLE
Fix condition where unnamed tab will prevent layout of remaining tabs

### DIFF
--- a/CloudyTabs/JPCloudTabsDBReader.m
+++ b/CloudyTabs/JPCloudTabsDBReader.m
@@ -81,7 +81,7 @@
         NSString *URL = [resultSet stringForColumn:@"url"];
         NSString *title = [resultSet stringForColumn:@"title"];
         
-        [tabs addObject:@{@"URL": URL, @"Title": title}];
+        [tabs addObject:@{@"URL": URL, @"Title": (title ? title : URL)}];
     }
     
     return [tabs copy];


### PR DESCRIPTION
I found that only the menus for my first device were laying out. It turns out that I had a tab whose title was returning as null, and adding null as the title would raise an exception in NSDictionary. 

This PR fixes that by providing a fallback value.