### PR TITLE
Add README section with workaround for macOS Mojavi start-up issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Hovering over the CloudyTabs menu bar icon displays a tooltip which lists the da
 * macOS 10.13 or later
 * An active iCloud account
 
+## Notes
+
+- If you find that CloudyTabs fails to start on macOS 10.14 Mojave, try adding CloudyTabs to "Full Disk Access" under `Security & Privacy > Privacy` in your System Preferences (see [Issue #48](https://github.com/josh-/CloudyTabs/issues/48)).
+
 ## License
 
 The MIT License (MIT)


### PR DESCRIPTION
This PR adds a `README` section with details on how to work around a recent issue with macOS 10.14 Mojave.